### PR TITLE
Replace some troublesome dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 'use strict';
 
 var RBush = require('rbush');
-var convexHull = require('monotone-convex-hull-2d');
 var Queue = require('tinyqueue');
 var pointInPolygon = require('point-in-polygon');
-var orient = require('robust-orientation')[3];
+const orient = require('robust-predicates/umd/orient2d.min.js').orient2d;
+const monotoneChainConvexHull = require('monotone-chain-convex-hull');
 
 module.exports = concaveman;
 module.exports.default = concaveman;
@@ -173,8 +173,8 @@ function noIntersections(a, b, segTree) {
 // check if the edges (p1,q1) and (p2,q2) intersect
 function intersects(p1, q1, p2, q2) {
     return p1 !== q2 && q1 !== p2 &&
-        orient(p1, q1, p2) > 0 !== orient(p1, q1, q2) > 0 &&
-        orient(p2, q2, p1) > 0 !== orient(p2, q2, q1) > 0;
+        orient(p1[0], p1[1], q1[0], q1[1], p2[0], p2[1]) > 0 !== orient(p1[0], p1[1], q1[0], q1[1], q2[0], q2[1]) > 0 &&
+        orient(p2[0], p2[1], q2[0], q2[1], p1[0], p1[1]) > 0 !== orient(p2[0], p2[1], q2[0], q2[1], q1[0], q1[1]) > 0;
 }
 
 // update the bounding box of a node's edge
@@ -212,12 +212,7 @@ function fastConvexHull(points) {
     }
 
     // get convex hull around the filtered points
-    var indices = convexHull(filtered);
-
-    // return the hull as array of points (rather than indices)
-    var hull = [];
-    for (i = 0; i < indices.length; i++) hull.push(filtered[indices[i]]);
-    return hull;
+    return monotoneChainConvexHull(filtered);
 }
 
 // create a new node in a doubly linked list

--- a/index.js
+++ b/index.js
@@ -169,11 +169,15 @@ function noIntersections(a, b, segTree) {
     return true;
 }
 
+function cross(p1, p2, p3) {
+    return orient(p1[0], p1[1], p2[0], p2[1], p3[0], p3[1]);
+}
+
 // check if the edges (p1,q1) and (p2,q2) intersect
 function intersects(p1, q1, p2, q2) {
     return p1 !== q2 && q1 !== p2 &&
-        orient(p1[0], p1[1], q1[0], q1[1], p2[0], p2[1]) > 0 !== orient(p1[0], p1[1], q1[0], q1[1], q2[0], q2[1]) > 0 &&
-        orient(p2[0], p2[1], q2[0], q2[1], p1[0], p1[1]) > 0 !== orient(p2[0], p2[1], q2[0], q2[1], q1[0], q1[1]) > 0;
+        cross(p1, q1, p2) > 0 !== cross(p1, q1, q2) > 0 &&
+        cross(p2, q2, p1) > 0 !== cross(p2, q2, q1) > 0;
 }
 
 // update the bounding box of a node's edge
@@ -345,14 +349,12 @@ function sqSegSegDist(x0, y0, x1, y1, x2, y2, x3, y3) {
     return dx * dx + dy * dy;
 }
 
-function cross(p1, p2, p3) {
-    return orient(p1[0], p1[1], p2[0], p2[1], p3[0], p3[1]);
+function compareByX(a, b) {
+    return a[0] === b[0] ? a[1] - b[1] : a[0] - b[0];
 }
 
 function convexHull(points) {
-    points.sort(function (a, b) {
-        return a[0] === b[0] ? a[1] - b[1] : a[0] - b[0];
-    });
+    points.sort(compareByX);
 
     var lower = [];
     for (var i = 0; i < points.length; i++) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Fast 2D concave hull algorithm in JavaScript (generates an outline of a point set)",
   "main": "index.js",
   "dependencies": {
-    "monotone-chain-convex-hull": "^1.0.0",
     "point-in-polygon": "^1.0.1",
     "rbush": "^3.0.0",
     "robust-predicates": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -4,18 +4,20 @@
   "description": "Fast 2D concave hull algorithm in JavaScript (generates an outline of a point set)",
   "main": "index.js",
   "dependencies": {
-    "monotone-convex-hull-2d": "^1.0.1",
+    "monotone-chain-convex-hull": "^1.0.0",
     "point-in-polygon": "^1.0.1",
     "rbush": "^3.0.0",
-    "robust-orientation": "^1.1.3",
+    "robust-predicates": "^2.0.4",
     "tinyqueue": "^2.0.3"
   },
   "devDependencies": {
     "eslint": "^4.19.1",
     "eslint-config-mourner": "^2.0.1",
+    "benchmark": "^2.1.4",
     "tape": "^4.10.2"
   },
   "scripts": {
+    "bench": "node test/bench.js",
     "pretest": "eslint index.js test/*.js",
     "test": "tape test/test.js"
   },

--- a/package.json
+++ b/package.json
@@ -13,11 +13,9 @@
   "devDependencies": {
     "eslint": "^4.19.1",
     "eslint-config-mourner": "^2.0.1",
-    "benchmark": "^2.1.4",
     "tape": "^4.10.2"
   },
   "scripts": {
-    "bench": "node test/bench.js",
     "pretest": "eslint index.js test/*.js",
     "test": "tape test/test.js"
   },


### PR DESCRIPTION
Resolves #16

- [x] replace robust-orientation with robust-predicates, and 
- [x] replace monotone-convex-hull-2d with [monotone-chain-convex-hull](https://www.npmjs.com/package/monotone-chain-convex-hull)
  - I did look at inlining the convex hull algorithm using the one suggested however it produced different results whereas the other package I picked produced the same results out of the box. Looks like there are a few minor variations in the implementation.

I did also do a before/after performance comparison and there seems to be negligible difference. If you're interested I'm happy to submit the benchmark setup I created with benchmarkjs.