### PR TITLE
convert to esm and add rollup for esm + cjs build

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+    "parserOptions": {
+        "ecmaVersion": "2015",
+        "sourceType": "module"
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules
 coverage
 .nyc_output
 tmp
+dist
 *.log
 viz/bundle.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 node_js:
   - "12"
   - node
+script:
+  - yarn build
+  - yarn test

--- a/index.js
+++ b/index.js
@@ -1,17 +1,11 @@
 'use strict';
 
-var RBush = require('rbush');
-var Queue = require('tinyqueue');
-var pointInPolygon = require('point-in-polygon');
-var orient = require('robust-predicates/umd/orient2d.min.js').orient2d;
+import RBush from 'rbush';
+import Queue from 'tinyqueue';
+import { nested as pointInPolygon } from 'point-in-polygon';
+import { orient2d as orient } from 'robust-predicates';
 
-// Fix for require issue in webpack https://github.com/mapbox/concaveman/issues/18
-if (Queue.default) {
-    Queue = Queue.default;
-}
-
-module.exports = concaveman;
-module.exports.default = concaveman;
+export default concaveman
 
 function concaveman(points, concavity, lengthThreshold) {
     // a relative measure of concavity; higher value means simpler hull

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "concaveman",
   "version": "1.2.1",
   "description": "Fast 2D concave hull algorithm in JavaScript (generates an outline of a point set)",
-  "main": "index.js",
+  "module": "index.js",
+  "main": "./dist/index-cjs.js",
   "dependencies": {
     "point-in-polygon": "^1.1.0",
     "rbush": "^3.0.1",
@@ -12,9 +13,11 @@
   "devDependencies": {
     "eslint": "^7.32.0",
     "eslint-config-mourner": "^2.0.1",
+    "rollup": "^2.67.2",
     "tape": "^5.3.1"
   },
   "scripts": {
+    "build": "rollup -c",
     "pretest": "eslint index.js test/*.js",
     "test": "tape test/test.js"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,18 @@
+export default {
+  input: "index.js",
+  output: [{
+    name: "concaveman",
+    format: "cjs",
+    indent: false,
+    file: './dist/index-cjs.js',
+    exports: 'auto'
+  },
+  {
+    name: "concaveman",
+    format: "esm",
+    indent: false,
+    file: './dist/index-esm.js',
+  }],
+  external: ['rbush', 'tinyqueue', 'point-in-polygon', 'robust-predicates'],
+  plugins: []
+}

--- a/test/debug.js
+++ b/test/debug.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var fs = require('fs');
-var concaveman = require('../');
+var concaveman = require('../dist/index-cjs');
 
 var points = require('../tmp/test.json');
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var test = require('tape').test;
-var concaveman = require('../');
+var concaveman = require('../dist/index-cjs');
 
 var points = require('./fixtures/points-1k.json');
 var hull = require('./fixtures/points-1k-hull.json');

--- a/yarn.lock
+++ b/yarn.lock
@@ -562,6 +562,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
+fsevents@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -1151,6 +1156,13 @@ robust-predicates@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-2.0.4.tgz#0a2367a93abd99676d075981707f29cfb402248b"
   integrity sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==
+
+rollup@^2.67.2:
+  version "2.67.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.67.2.tgz#d95e15f60932ad21e05a870bd0aa0b235d056f04"
+  integrity sha512-hoEiBWwZtf1QdK3jZIq59L0FJj4Fiv4RplCO4pvCRC86qsoFurWB4hKQIjoRf3WvJmk5UZ9b0y5ton+62fC7Tw==
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 semver@^7.2.1:
   version "7.3.2"


### PR DESCRIPTION
Scope:
* convert main module to esm to enable usage in esbuild based setups ( like vite.js ) which currently doesn't work: `RBush2 is not a constructor`
* use rollup to create a commonjs package for backwards compatibility
* tests use commonjs bundle